### PR TITLE
Refactor EvaluateScore to hold game state more consistently, implement Russian Roulette

### DIFF
--- a/CDGGameModes.lua
+++ b/CDGGameModes.lua
@@ -131,17 +131,54 @@ CDG_INVERSE = {
 
 -- Russian Roullette
 -- ===================
-CDG_ROULETTE= {
-	label = "Roulette",
-	
+CDG_ROULETTE = {
+	label = "Russian Roulette",
+
 	init_game = function(game)
 		game.data.roll_lower = 1
 		game.data.roll_upper = 6
 		game.data.roll_range = "(1-6)"
+		game.data.w_bullets = 6
+		game.data.l_bullets = nil
+		game.data.low_tiebreak_callback = function(game)
+			if not game.data.l_bullets then
+				game.data.l_bullets = game.data.w_bullets
+			end
+			if game.data.l_bullets > 2 then
+				game.data.l_bullets = game.data.l_bullets - 1
+			else
+				game.data.l_bullets = 6
+			end
+			game.data.roll_upper = game.data.l_bullets
+			game.data.roll_range = "("..game.data.roll_lower.."-"..game.data.roll_upper..")"
+		end
+		game.data.high_tiebreak_callback = function(game)
+			if game.data.w_bullets > 2 then
+				game.data.w_bullets = game.data.w_bullets - 1
+			else
+				game.data.w_bullets = 6
+			end
+			game.data.roll_upper = game.data.w_bullets
+			game.data.roll_range = "("..game.data.roll_lower.."-"..game.data.roll_upper..")"
+		end
+		game.data.only_losers_callback = function(game)
+			if game.data.round == "winners" then
+				game.data.w_bullets = 6
+				game.data.roll_upper = game.data.w_bullets
+			elseif game.data.round == "losers" then
+				game.data.l_bullets = 6
+				game.data.roll_upper = game.data.l_bullets
+			else -- Initial round --
+				game.data.w_bullets = 6
+				game.data.l_bullets = 6
+				game.data.roll_upper = 6
+			end
+			game.data.roll_range = "("..game.data.roll_lower.."-"..game.data.roll_upper..")"
+		end
 	end,
 	
 	roll_to_score = function(roll)
-		if (tonumber(roll) == 1) then
+		if tonumber(roll) == 1 then
 			return 0 -- They LOSE
 		else
 			return 1
@@ -151,13 +188,15 @@ CDG_ROULETTE= {
 	fmt_score = function(roll) return roll end,
 	
 	sort_rolls = CDG_SORT_DESCENDING,
+
+	custom_intro = function()
+		return "Roll 1 and you're dead. Last player alive wins. First player dead loses."
+	end,
 	
 	payout = function(game)
 		game.data.cash_winnings = game.data.gold_amount
 	end,
-
 }
-
 
 -- Yahtzee
 -- ============

--- a/CalmDownandGamble.lua
+++ b/CalmDownandGamble.lua
@@ -493,7 +493,7 @@ function CalmDownandGamble:EvaluateScores()
 			self.game.data.player_rolls = self.game.data.low_tiebreak
 			self.game.data.round = "initial"
 			if self.game.data.only_losers_callback then
-				self.game.data.only_losers_callback(game)
+				self.game.data.only_losers_callback(self.game)
 			end
 
 		-- Only high rolls, reroll --
@@ -550,7 +550,7 @@ function CalmDownandGamble:EvaluateScores()
 			elseif high_roller_count == 0 then
 				self.game.data.low_tiebreak = self:CopyTable(low_roller_playoff)
 				if self.game.data.only_losers_callback then
-					self.game.data.only_losers_callback(game)
+					self.game.data.only_losers_callback(self.game)
 				end
 
 			-- Many losers, play losers --
@@ -602,7 +602,7 @@ function CalmDownandGamble:EvaluateScores()
 				self.game.data.player_rolls = self.game.data.high_tiebreak
 				self.game.data.round = "winners"
 				if self.game.data.only_losers_callback then
-					self.game.data.only_losers_callback(game)
+					self.game.data.only_losers_callback(self.game)
 				end
 
 			-- Shouldn't be reached --


### PR DESCRIPTION
EvaluateScores:
* Abstract StartRolls out of EvaluateScores to GameLoop
* game.data.high_tiebreak holds the table of rollers in the winners round
* game.data.lower_tiebreak holds the table of rollers in the losers round
* Game state now stored in game.data.round variable: "initial", "losers", "winners"
* Game starts in "initial" state, then EvaluateScore decides next state. 
* * Keep same state if a tie
* * losers if there are multiple losers, player rolls set to game.data.lower_tiebreak
* * winners if there are multiple winners, player rolls set to game.data.high_tiebreak
* Loser only determined in initial or losers state. Winner only determined in initial or winners state.

StartRolls:
* Add print message for ties on initial round

CDGGameModes:
Add RussianRoulette mode:
* Start with /roll 6
* Every subsequent roll is 1 less (/roll 5, /roll 4, /roll 3, etc.)
* After /roll 2, reset to /roll 6
* When everyone rolls 1, nullify result and reset to /roll 6
* Last person to not roll 1 wins, first person to roll 1 loses